### PR TITLE
Fix disk/read write error handling and add int13h LBA BIOS extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ bios.bin
 bios.lst
 tinyxms.sys
 tinyxms.lst
+quitemu.com
+quitemu.lst
 8086tiny
 hd.img

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,14 @@ bios.bin: bios.asm
 tinyxms.sys: tinyxms.asm
 	nasm -f bin -I ../lmacros/ -I lmacros/ -l tinyxms.lst -o tinyxms.sys tinyxms.asm
 
-8086tiny: 8086tiny.c bios.bin tinyxms.sys
+quitemu.com: quitemu.asm
+	nasm -f bin -o quitemu.com quitemu.asm
+
+8086tiny: 8086tiny.c bios.bin tinyxms.sys quitemu.com
 	${CC} 8086tiny.c ${OPTS_SDL} ${OPTS_ALL} -o 8086tiny
 	strip 8086tiny
 
-8086tiny_slowcpu: 8086tiny.c bios.bin tinyxms.sys
+8086tiny_slowcpu: 8086tiny.c bios.bin tinyxms.sys quitemu.com
 	${CC} 8086tiny.c ${OPTS_SDL} ${OPTS_ALL} ${OPTS_SLOWCPU} -o 8086tiny
 	strip 8086tiny
 
@@ -31,4 +34,4 @@ no_graphics: 8086tiny.c bios.bin tinyxms.sys
 	strip 8086tiny
 
 clean:
-	rm -f 8086tiny bios.bin bios.lst tinyxms.sys tinyxms.lst
+	rm -f 8086tiny bios.bin bios.lst tinyxms.sys tinyxms.lst quitemu.com

--- a/bios.asm
+++ b/bios.asm
@@ -94,13 +94,13 @@ bios_entry:
 .warm_early_boot:
 	mov	[cs:apm_flags], byte 0
 
+	push	ax
+
 	; Set CPU to high power
 	mov	ah, 1
 	db	0x0f, 0x05
 
 	; Set up Hercules graphics support. We start with the adapter in text mode
-
-	push	dx
 
 	mov	dx, 0x3b8
 	mov	al, 0
@@ -122,8 +122,6 @@ bios_entry:
 	; Graphics power on
 	mov	ah, 3
 	db	0x0f, 0x05
-
-	pop	dx
 
 	pop	ax
 

--- a/quitemu.asm
+++ b/quitemu.asm
@@ -34,7 +34,17 @@ help:
 	int	21h
 	ret
 go:
-	xchg	ax, dx
-	mov	bx, 0x1234	; Tell emulator to use AL as exit code
-	jmp	0:0		; Actual enstruction that exits emulator
+	mov	bp, 0x1234	; Tell emulator to use AL as exit code
+	xor	bx, bx
+	mov	ax, 5304h
+	int	15h
+	mov	ax, 5301h
+	int	15h
+	mov	ax, 5307h
+	mov	cx, 3
+	inc	bx
+	int	15h
+	mov	ax, 4C01h	; Power off failed
+	int	21h
+	ret			; DOS 1.0
 msg	db	'Quits 8086tiny emulator', 13, 10, 'Usage: QUITEMU [exit code]', 13, 10, '$'

--- a/quitemu.asm
+++ b/quitemu.asm
@@ -1,0 +1,40 @@
+CPU 8086
+
+BITS 16
+
+ORG 0x100
+
+	mov	si, 0x80
+	lodsb
+	mov	bl, al
+	mov	bh, 0
+	add	bx, si
+	mov	cl, 10
+	xor	dx, dx
+lop:
+	cmp	si, bx
+	je	go
+	lodsb
+	cmp	al, ' '
+	je	lop
+	cmp	al, 9
+	je	lop
+	sub	al, '0'
+	jb	help
+	cmp	al, 9
+	ja	help
+	xchg	ax, dx
+	mul	cl
+	add	al, dl
+	xchg	ax, dx
+	jmp	lop
+help:
+	mov	dx, msg
+	mov	ah, 9
+	int	21h
+	ret
+go:
+	xchg	ax, dx
+	mov	bx, 0x1234	; Tell emulator to use AL as exit code
+	jmp	0:0		; Actual enstruction that exits emulator
+msg	db	'Quits 8086tiny emulator', 13, 10, 'Usage: QUITEMU [exit code]', 13, 10, '$'

--- a/runme
+++ b/runme
@@ -7,4 +7,6 @@ then
 else
     ./8086tiny bios.bin fd.img
 fi
+Q=$?
 stty cooked echo
+exit $Q


### PR DESCRIPTION
Resolves #6 but that's just the tip of the iceberg.

The hard disk geometry detection is very dodgy indeed; and rather than try to fix it I decided I won't fix it and just go ahead and implement int 13h AH=42h/43h so I don't have to worry about the disk geometry detector doing something dumb in FreeDOS disk images.

I also added a numeric argument to quitemu; I see potential use cases for this in the future.